### PR TITLE
Allow to unwrap textproto errors from smtp connection failures

### DIFF
--- a/email.go
+++ b/email.go
@@ -713,7 +713,7 @@ func dial(host string, port string, encryption encryption, config *tls.Config) (
 	c, err := newClient(conn, host)
 
 	if err != nil {
-		return nil, errors.New("Mail Error on smtp dial: " + err.Error())
+		return nil, fmt.Errorf("Mail Error on smtp dial: %w", err)
 	}
 
 	return c, err
@@ -732,7 +732,7 @@ func smtpConnect(host string, port string, a auth, encryption encryption, config
 	// send Hello
 	if err = c.hi("localhost"); err != nil {
 		c.close()
-		return nil, errors.New("Mail Error on Hello: " + err.Error())
+		return nil, fmt.Errorf("Mail Error on Hello: %w", err)
 	}
 
 	// start TLS if necessary
@@ -744,7 +744,7 @@ func smtpConnect(host string, port string, a auth, encryption encryption, config
 
 			if err = c.startTLS(config); err != nil {
 				c.close()
-				return nil, errors.New("Mail Error on Start TLS: " + err.Error())
+				return nil, fmt.Errorf("Mail Error on Start TLS: %w", err)
 			}
 		}
 	}
@@ -754,7 +754,7 @@ func smtpConnect(host string, port string, a auth, encryption encryption, config
 		if ok, _ := c.extension("AUTH"); ok {
 			if err = c.authenticate(a); err != nil {
 				c.close()
-				return nil, errors.New("Mail Error on Auth: " + err.Error())
+				return nil, fmt.Errorf("Mail Error on Auth: %w", err)
 			}
 		}
 	}


### PR DESCRIPTION
Currently is not possible to check exactly why a SMTP connection failed exactly (invalid username/password, quota exceeded, etc). This change allows to use the error unwrap feature from Go 1.13 and get the original textproto error (if present) to read the SMTP resulting code + message. For example:

```go
protoErr := &textproto.Error{}
if errors.As(err, &protoErr) {
	// protoErr.Code can be checked and protoErr.Msg can be parsed to extract the extended code.
}
```

The change does not break existing code as the error message continues to be the same.