### PR TITLE
Allow to pass a custom tls.Config to the SMTP server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ func main() {
 	
 	//Timeout for send the data and wait respond
 	server.SendTimeout = 10 * time.Second
+
+    /*
+    You can provide a custom TLS configuration, for example to skip TLS
+    verification for testing.
+
+    code:
+    server.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+    */
 	
 	//SMTP client
 	smtpClient,err :=server.Connect()


### PR DESCRIPTION
Providing a custom TLS config is important for some use cases. Some examples are to provide a custom certificate, to disable TLS verification or just for testing.

Also this fixes ServerName not being set when using EncryptionSSL (it was only set for EncryptionTLS).