### PR TITLE
Cleanup, first pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Go Simple Mail supports:
 - Timeout for connect to a SMTP Server
 - Timeout for send an email
 - Return Path
-- Alternaive Email Body
+- Alternative Email Body
 - CC and BCC
 - Add Custom Headers in Message
 - Send NOOP, RESET, QUIT and CLOSE to SMTP client
@@ -91,7 +91,7 @@ import (
 	"github.com/xhit/go-simple-mail/v2"
 )
 
-const htmlBody := `<html>
+const htmlBody = `<html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<title>Hello Gophers!</title>

--- a/README.md
+++ b/README.md
@@ -8,17 +8,23 @@ The best way to send emails in Go with SMTP Keep Alive and Timeout for Connect a
 
 # IMPORTANT
 
-Examples in this readme is for v2.2.0 and above. 
+Examples in this README are for v2.2.0 and above. Examples for older versions
+can be found [here](https://gist.github.com/xhit/54516917473420a8db1b6fff68a21c99).
 
-Minimun Go version: 1.13
+The minimum Go version is 1.13, for Go 1.12 and older use branch `go1.12`.
 
-For Go 1.12 and below, use branch `go1.12`.
+Breaking change in 2.2.0: The signature of `SetBody` and `AddAlternative` used
+to accept strings ("text/html" and "text/plain") and not require on of the
+`contentType` constants (`TextHTML` or `TextPlain`). Upgrading, while not
+quite following semantic versioning, is quite simple:
 
-Versions <= v2.1.3 use strings "text/html" and "text/plain" in `SetBody` and `AddAlternative`.
-
-Examples for versions <= v2.0.0 go here: https://gist.github.com/xhit/54516917473420a8db1b6fff68a21c99
-
-The base of this package is mail package from **Joe Grasse** https://github.com/joegrasse/mail and mime package of same author https://github.com/joegrasse/mime that are not supported since Jun 29, 2018 and Oct 1, 2015 respectively. A lot of changes in Go Simple Mail were sent with not response.
+```diff
+  email := mail.NewMSG()
+- email.SetBody("text/html", htmlBody)
+- email.AddAlternative("text/plain", plainBody)
++ email.SetBody(mail.TextHTML, htmlBody)
++ email.AddAlternative(mail.TextPlain, plainBody)
+```
 
 # Introduction
 
@@ -28,9 +34,17 @@ documented.
 Go Simple Mail can only send emails using an SMTP server. But the API is flexible and it
 is easy to implement other methods for sending emails using a local Postfix, an API, etc.
 
+This package contains (and is based on) two packages by **Joe Grasse**:
+
+- https://github.com/joegrasse/mail (unmaintained since Jun 29, 2018), and
+- https://github.com/joegrasse/mime (unmaintained since Oct 1, 2015).
+
+A lot of changes in Go Simple Mail were sent with not response.
+
 ## Features
 
 Go Simple Mail supports:
+
 - Multiple Attachments with path
 - Multiple Attachments in base64
 - Multiple Recipients
@@ -51,8 +65,8 @@ Go Simple Mail supports:
 - CC and BCC
 - Add Custom Headers in Message
 - Send NOOP, RESET, QUIT and CLOSE to SMTP client
-- PLAIN, LOGIN and CRAM-MD5 Authentication ( >= v2.3.0)
-- Custom TLS Configuration (>= v2.5.0)
+- PLAIN, LOGIN and CRAM-MD5 Authentication (since v2.3.0)
+- Custom TLS Configuration (since v2.5.0)
 
 ## Documentation
 
@@ -60,10 +74,10 @@ https://pkg.go.dev/github.com/xhit/go-simple-mail/v2?tab=doc
 
 ## Download
 
-This package use go modules.
+This package uses go modules.
 
-```bash
-go get github.com/xhit/go-simple-mail/v2
+```console
+$ go get github.com/xhit/go-simple-mail/v2
 ```
 
 # Usage
@@ -72,69 +86,61 @@ go get github.com/xhit/go-simple-mail/v2
 package main
 
 import (
-	"github.com/xhit/go-simple-mail/v2"
 	"log"
+
+	"github.com/xhit/go-simple-mail/v2"
 )
 
+const htmlBody := `<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<title>Hello Gophers!</title>
+	</head>
+	<body>
+		<p>This is the <b>Go gopher</b>.</p>
+		<p><img src="cid:Gopher.png" alt="Go gopher" /></p>
+		<p>Image created by Renee French</p>
+	</body>
+</html>`
+
 func main() {
-
-	htmlBody :=
-	`<html>
-		<head>
-			<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-			<title>Hello Gophers!</title>
-		</head>
-		<body>
-			<p>This is the <b>Go gopher</b>.</p>
-			<p><img src="cid:Gopher.png" alt="Go gopher" /></p>
-			<p>Image created by Renee French</p>
-		</body>
-	</html>`
-
 	server := mail.NewSMTPClient()
-	
-	//SMTP Server
+
+	// SMTP Server
 	server.Host = "smtp.example.com"
 	server.Port = 587
 	server.Username = "test@example.com"
 	server.Password = "examplepass"
 	server.Encryption = mail.EncryptionTLS
 
-	/*
-	In version >=2.3.0 you can specified authentication type: PLAIN, LOGIN, CRAM-MD5
-	if not specified, default is mail.AuthPlain
+	// Since v2.3.0 you can specified authentication type:
+	// - PLAIN (default)
+	// - LOGIN
+	// - CRAM-MD5
+	// server.Authentication = mail.AuthPlain
 
-	code:
-	server.Authentication = mail.AuthPlain
-	*/
-	
-	//Variable to keep alive connection
+	// Variable to keep alive connection
 	server.KeepAlive = false
-	
-	//Timeout for connect to SMTP Server
+
+	// Timeout for connect to SMTP Server
 	server.ConnectTimeout = 10 * time.Second
-	
-	//Timeout for send the data and wait respond
+
+	// Timeout for send the data and wait respond
 	server.SendTimeout = 10 * time.Second
 
-	/*
-	You can provide a custom TLS configuration, for example to skip TLS
-	verification for testing.
-
-	code:
+	// Set TLSConfig to provide custom TLS configuration. For example,
+	// to skip TLS verification (useful for testing):
 	server.TLSConfig = &tls.Config{InsecureSkipVerify: true}
-	*/
-	
-	//SMTP client
-	smtpClient,err :=server.Connect()
-	
+
+	// SMTP client
+	smtpClient,err := server.Connect()
+
 	if err != nil{
 		log.Fatal(err)
 	}
 
-	//New email simple html with inline and CC
+	// New email simple html with inline and CC
 	email := mail.NewMSG()
-
 	email.SetFrom("From Example <nube@example.com>").
 		AddTo("xhit@example.com").
 		AddCc("otherto@example.com").
@@ -144,9 +150,8 @@ func main() {
 
 	email.AddInline("/path/to/image.png", "Gopher.png")
 
-	//Call Send and pass the client
+	// Call Send and pass the client
 	err = email.Send(smtpClient)
-
 	if err != nil {
 		log.Println(err)
 	} else {
@@ -161,23 +166,22 @@ func main() {
 	//Set your smtpClient struct to keep alive connection
 	server.KeepAlive = true
 
-	toList := [3]string{"to1@example1.com", "to3@example2.com", "to4@example3.com"}
-
-	for _, to := range toList {
-		//New email simple html with inline and CC
+	for _, to := range []string{
+		"to1@example1.com",
+		"to3@example2.com",
+		"to4@example3.com",
+	} {
+		// New email simple html with inline and CC
 		email := mail.NewMSG()
-
 		email.SetFrom("From Example <nube@example.com>").
 			AddTo(to).
 			SetSubject("New Go Email")
 
 		email.SetBody(mail.TextHTML, htmlBody)
-
 		email.AddInline("/path/to/image.png", "Gopher.png")
 
-		//Call Send and pass the client
+		// Call Send and pass the client
 		err = email.Send(smtpClient)
-
 		if err != nil {
 			log.Println(err)
 		} else {
@@ -185,3 +189,7 @@ func main() {
 		}
 	}
 ```
+
+## More examples
+
+See [example/example_test.go](example/example_test.go).

--- a/email.go
+++ b/email.go
@@ -610,8 +610,8 @@ func (email *Email) attachB64(b64File string, name string) error {
 	return nil
 }
 
-// getFrom returns the sender of the email, if any
-func (email *Email) getFrom() string {
+// GetFrom returns the sender of the email, if any
+func (email *Email) GetFrom() string {
 	from := email.returnPath
 	if from == "" {
 		from = email.sender

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -1,11 +1,13 @@
-package mail
+package example
 
 import (
 	"testing"
 	"time"
+
+	mail "github.com/xhit/go-simple-mail/v2"
 )
 
-//Some variables to connect and the body
+// Some variables to connect and the body.
 var (
 	htmlBody = `<html>
 	<head>
@@ -23,15 +25,14 @@ var (
 	port           = 25
 	username       = "test@example.com"
 	password       = "santiago"
-	encryptionType = EncryptionNone
+	encryptionType = mail.EncryptionNone
 	connectTimeout = 10 * time.Second
 	sendTimeout    = 10 * time.Second
 )
 
-//TestSendMailWithAttachment send a simple html email
+// TestSendMailWithAttachment send a simple html email.
 func TestSendMail(t *testing.T) {
-
-	client := NewSMTPClient()
+	client := mail.NewSMTPClient()
 
 	//SMTP Client
 	client.Host = host
@@ -59,14 +60,14 @@ func TestSendMail(t *testing.T) {
 	}
 
 	//Create the email message
-	email := NewMSG()
+	email := mail.NewMSG()
 
 	email.SetFrom("From Example <test@example.com>").
 		AddTo("admin@example.com").
 		SetSubject("New Go Email")
 
-	email.SetBody(TextHTML, htmlBody)
-	email.AddAlternative(TextPlain, "Hello Gophers!")
+	email.SetBody(mail.TextHTML, htmlBody)
+	email.AddAlternative(mail.TextPlain, "Hello Gophers!")
 
 	//Some additional options to send
 	email.SetSender("xhit@test.com")
@@ -88,7 +89,7 @@ func TestSendMail(t *testing.T) {
 	email.SetDate("2015-04-28 10:32:00 CDT")
 
 	//Send with low priority
-	email.SetPriority(PriorityLow)
+	email.SetPriority(mail.PriorityLow)
 
 	//Pass the client to the email message to send it
 	err = email.Send(smtpClient)
@@ -99,13 +100,11 @@ func TestSendMail(t *testing.T) {
 	if err != nil {
 		t.Error("Expected nil, got", err, "sending email")
 	}
-
 }
 
-//TestSendMultipleEmails send multiple emails in same connection
+// TestSendMultipleEmails send multiple emails in same connection.
 func TestSendMultipleEmails(t *testing.T) {
-
-	client := NewSMTPClient()
+	client := mail.NewSMTPClient()
 
 	//SMTP Client
 	client.Host = host
@@ -117,7 +116,7 @@ func TestSendMultipleEmails(t *testing.T) {
 	client.SendTimeout = sendTimeout
 
 	//For authentication you can use AuthPlain, AuthLogin or AuthCRAMMD5
-	client.Authentication = AuthPlain
+	client.Authentication = mail.AuthPlain
 
 	//KeepAlive true because the connection need to be open for multiple emails
 	//For avoid inactivity timeout, every 30 second you can send a NO OPERATION command to smtp client
@@ -139,23 +138,22 @@ func TestSendMultipleEmails(t *testing.T) {
 			t.Error("Expected nil, got", err, "sending email")
 		}
 	}
-
 }
 
-func sendEmail(htmlBody string, to string, smtpClient *SMTPClient) error {
+func sendEmail(htmlBody string, to string, smtpClient *mail.SMTPClient) error {
 	//Create the email message
-	email := NewMSG()
+	email := mail.NewMSG()
 
 	email.SetFrom("From Example <from.email@example.com>").
 		AddTo(to).
 		SetSubject("New Go Email")
 
 	//Get from each mail
-	email.getFrom()
-	email.SetBody(TextHTML, htmlBody)
+	email.GetFrom()
+	email.SetBody(mail.TextHTML, htmlBody)
 
 	//Send with high priority
-	email.SetPriority(PriorityHigh)
+	email.SetPriority(mail.PriorityHigh)
 
 	//Pass the client to the email message to send it
 	err := email.Send(smtpClient)
@@ -163,16 +161,16 @@ func sendEmail(htmlBody string, to string, smtpClient *SMTPClient) error {
 	return err
 }
 
-//TestWithTLS using gmail port 587
+// TestWithTLS using gmail port 587.
 func TestWithTLS(t *testing.T) {
-	client := NewSMTPClient()
+	client := mail.NewSMTPClient()
 
 	//SMTP Client
 	client.Host = "smtp.gmail.com"
 	client.Port = 587
 	client.Username = "aaa@gmail.com"
 	client.Password = "asdfghh"
-	client.Encryption = EncryptionTLS
+	client.Encryption = mail.EncryptionTLS
 	client.ConnectTimeout = 10 * time.Second
 	client.SendTimeout = 10 * time.Second
 
@@ -189,19 +187,18 @@ func TestWithTLS(t *testing.T) {
 	if err != nil {
 		t.Error("Expected nil, got", err, "sending email")
 	}
-
 }
 
-//TestWithTLS using gmail port 465
+// TestWithTLS using gmail port 465.
 func TestWithSSL(t *testing.T) {
-	client := NewSMTPClient()
+	client := mail.NewSMTPClient()
 
 	//SMTP Client
 	client.Host = "smtp.gmail.com"
 	client.Port = 465
 	client.Username = "aaa@gmail.com"
 	client.Password = "asdfghh"
-	client.Encryption = EncryptionSSL
+	client.Encryption = mail.EncryptionSSL
 	client.ConnectTimeout = 10 * time.Second
 	client.SendTimeout = 10 * time.Second
 
@@ -218,5 +215,4 @@ func TestWithSSL(t *testing.T) {
 	if err != nil {
 		t.Error("Expected nil, got", err, "sending email")
 	}
-
 }


### PR DESCRIPTION
The first commit moves the examples into a separate package. As mentioned in #7, the `example_test.go` would not even compile. I fixed that by exporting `(*Email) GetFrom()`.

In the second commit, I took the liberty to format the README a bit by improving the wording. I'm not sure why git thinks I've changed the whole file. Maybe the line endings changed? Anyway, feel free to omit this commit when merging.