### PR TITLE
Allow sending mail with different envelope from.

### DIFF
--- a/email.go
+++ b/email.go
@@ -723,9 +723,18 @@ func (email *Email) GetMessage() string {
 
 // Send sends the composed email
 func (email *Email) Send(client *SMTPClient) error {
+	return email.SendEnvelopeFrom(email.from, client)
+}
 
+// SendEnvelopeFrom sends the composed email with envelope
+// sender. 'from' must be an email address.
+func (email *Email) SendEnvelopeFrom(from string, client *SMTPClient) error {
 	if email.Error != nil {
 		return email.Error
+	}
+
+	if from == "" {
+		from = email.from
 	}
 
 	if len(email.recipients) < 1 {
@@ -734,8 +743,7 @@ func (email *Email) Send(client *SMTPClient) error {
 
 	msg := email.GetMessage()
 
-	return send(email.from, email.recipients, msg, client)
-
+	return send(from, email.recipients, msg, client)
 }
 
 // dial connects to the smtp server with the request encryption type


### PR DESCRIPTION
It's often necessary to send mails where the 'From' header and the SMTP envelope email address differ. The new function 'SendEnvelopeFrom' allows this. 