### PR TITLE
Fix add header for correct get from headers

### DIFF
--- a/email.go
+++ b/email.go
@@ -441,6 +441,9 @@ func (email *Email) AddHeader(header string, values ...string) *Email {
 		return email
 	}
 
+	// Set header to correct canonical Mime
+	header = textproto.CanonicalMIMEHeaderKey(header)
+
 	switch header {
 	case "Sender":
 		fallthrough


### PR DESCRIPTION
When i'm add headers  to Email. I have problem **AddHeader** not  use CanonicalMIMEHeaderKey
For example i put 

```
email := mail.NewMSG()
email.AddHeader("Message-ID", "test") 
```

And get it in internal (for example i used it for set TRASID from rfc1845)

```
email.headers.Get('Message-ID")
```

I got empty string because

```
func (h MIMEHeader) Get(key string) string {
	if h == nil {
		return ""
	}
	v := h[CanonicalMIMEHeaderKey(key)]
	if len(v) == 0 {
		return ""
	}
	return v[0]
}
```

When i'm run Get Message-ID this rewrite to Message-Id. 

My patch fix this problem and Get worked as expected. Also this fixed all non canonical key name in code