### PR TITLE
go-simple-mail can send email from a RFC822 formatted message.

### DIFF
--- a/email.go
+++ b/email.go
@@ -680,6 +680,11 @@ func (email *Email) GetFrom() string {
 	return from
 }
 
+// GetRecipients returns a slice of recipients emails
+func (email *Email) GetRecipients() []string {
+	return email.recipients
+}
+
 func (email *Email) hasMixedPart() bool {
 	return (len(email.parts) > 0 && len(email.attachments) > 0) || len(email.attachments) > 1
 }
@@ -692,7 +697,7 @@ func (email *Email) hasAlternativePart() bool {
 	return len(email.parts) > 1
 }
 
-// GetMessage builds and returns the email message
+// GetMessage builds and returns the email message (RFC822 formatted message)
 func (email *Email) GetMessage() string {
 	msg := newMessage(email)
 
@@ -904,6 +909,19 @@ func (smtpClient *SMTPClient) Quit() error {
 // Close closes the connection
 func (smtpClient *SMTPClient) Close() error {
 	return smtpClient.Client.close()
+}
+
+// SendMessage sends a message (a RFC822 formatted message)
+// 'from' must be an email address, recipients must be a slice of email address
+func SendMessage(from string, recipients []string, msg string, client *SMTPClient) error {
+	if from == "" {
+		return errors.New("Mail Error: No From email specifier")
+	}
+	if len(recipients) < 1 {
+		return errors.New("Mail Error: No recipient specified")
+	}
+
+	return send(from, recipients, msg, client)
 }
 
 // send does the low level sending of the email

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/xhit/go-simple-mail/v2
+module github.com/vjeantet/go-simple-mail/v2
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/vjeantet/go-simple-mail/v2
+module github.com/xhit/go-simple-mail/v2
 
 go 1.13


### PR DESCRIPTION
Hello,

This a PR which allow go-simple-mail to send email from a RFC822 message.
I have 2 usecases which needed this change 

**Usecase 1 : Delayed delivery** 
my app creates mail.Mail messages but send them only 3 or 4 days after ; 
- it save the Message(RFC822) got with *Email.GetMessage() into DB
- 3 or 4 days later, it takes it and send them to smtp server.

**Usecase 2 : S/MIME Encrypted mail** 
After retrieving the RFC822 message, i envelope it with S/MIME and get a new RFC822 message.

Hope it helps.

## Changes
- new function mail.SendMessage(from, recipients, msg, client) error
- Email exports a GetRecipients() function to get all recipients emails