### PR TITLE
Add golangci-lint action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,20 @@
+name: golangci-lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.35.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,9 @@ output:
 
 # all available settings of specific linters
 linters-settings:
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
   misspell:
     locale: US
   unused:
@@ -31,6 +34,7 @@ linters:
     - exportloopref
     - golint
     - gosimple
+    - govet
     - ineffassign
     - megacheck
     - misspell
@@ -44,7 +48,6 @@ linters:
     - varcheck
   disable:
     - errcheck
-    - govet
   disable-all: false
   fast: false
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,56 @@
+# This file contains all available configuration options
+# with their default values.
+
+# options for analysis running
+run:
+  concurrency: 4
+  timeout: 10m
+  issues-exit-code: 1
+  tests: true
+
+# output configuration options
+output:
+  format: line-number
+
+# all available settings of specific linters
+linters-settings:
+  misspell:
+    locale: US
+  unused:
+    # treat code as a program (not a library) and report unused exported identifiers; default is false.
+    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false
+
+linters:
+  enable:
+    - asciicheck
+    - dogsled
+    - exportloopref
+    - golint
+    - gosimple
+    - ineffassign
+    - megacheck
+    - misspell
+    - nakedret
+    - nolintlint
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+  disable:
+    - deadcode
+    - errcheck
+    - govet
+    - unused
+    - varcheck
+  disable-all: false
+  fast: false
+
+issues:
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters-settings:
 linters:
   enable:
     - asciicheck
+    - deadcode
     - dogsled
     - exportloopref
     - golint
@@ -39,12 +40,11 @@ linters:
     - structcheck
     - typecheck
     - unconvert
-  disable:
-    - deadcode
-    - errcheck
-    - govet
     - unused
     - varcheck
+  disable:
+    - errcheck
+    - govet
   disable-all: false
   fast: false
 

--- a/header.go
+++ b/header.go
@@ -184,15 +184,6 @@ func secureHeader(text []byte) []byte {
 	return []byte(secureValue)
 }
 
-// isQtext returns true if c is an RFC 5322 qtext character.
-func isQtext(c byte) bool {
-	// Printable US-ASCII, excluding backslash or quote.
-	if c == '\\' || c == '"' {
-		return false
-	}
-	return '!' <= c && c <= '~'
-}
-
 // isVchar returns true if c is an RFC 5322 VCHAR character.
 func isVchar(c byte) bool {
 	// Visible (printing) characters.

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -626,16 +626,16 @@ func TestNewClientWithTLS(t *testing.T) {
 	}
 
 	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			t.Errorf("server: accept: %v", err)
+		conn, errAccept := ln.Accept()
+		if errAccept != nil {
+			t.Errorf("server: accept: %v", errAccept)
 			return
 		}
 		defer conn.Close()
 
-		_, err = conn.Write([]byte("220 SIGNS\r\n"))
-		if err != nil {
-			t.Errorf("server: write: %v", err)
+		_, errWrite := conn.Write([]byte("220 SIGNS\r\n"))
+		if errWrite != nil {
+			t.Errorf("server: write: %v", errWrite)
 			return
 		}
 	}()

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -783,30 +783,6 @@ var helloClient = []string{
 	"NOOP\n",
 }
 
-var sendMailServer = `220 hello world
-502 EH?
-250 mx.google.com at your service
-250 Sender ok
-250 Receiver ok
-354 Go ahead
-250 Data ok
-221 Goodbye
-`
-
-var sendMailClient = `EHLO localhost
-HELO localhost
-MAIL FROM:<test@example.com>
-RCPT TO:<other@example.com>
-DATA
-From: test@example.com
-To: other@example.com
-Subject: SendMail test
-
-SendMail is working for me.
-.
-QUIT
-`
-
 func TestAuthFailed(t *testing.T) {
 	server := strings.Join(strings.Split(authFailedServer, "\n"), "\r\n")
 	client := strings.Join(strings.Split(authFailedClient, "\n"), "\r\n")


### PR DESCRIPTION
Add golangci-lint action

Use permissive configuration to ease follow up
of changes, fixes reported by the linter

Applied fixes:
- Fix deadcode, unused and varcheck lint errors
- Fix govet lint errors

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>
