### PR TITLE
Properly detect mime type when attaching using base64

### DIFF
--- a/email.go
+++ b/email.go
@@ -657,7 +657,7 @@ func (email *Email) attachB64(b64File string, name string) error {
 	}
 
 	// get the file mime type
-	mimeType := mime.TypeByExtension(name)
+	mimeType := mime.TypeByExtension(filepath.Ext(name))
 	if mimeType == "" {
 		mimeType = "application/octet-stream"
 	}


### PR DESCRIPTION
When attaching base64 files with AddAttachmentBase64, the private function attachB64 currently calls mime.TypeByExtension passing the whole filename instead of the extension. This PR wraps the variable with filepath.Ext as we already do in other places like attachData.