### PR TITLE
Adds text/calendar content type

### DIFF
--- a/email.go
+++ b/email.go
@@ -109,9 +109,11 @@ const (
 	TextPlain contentType = iota
 	// TextHTML sets body type to text/html in message body
 	TextHTML
+	// TextCalendar sets body type to text/calendar in message body
+	TextCalendar
 )
 
-var contentTypes = [...]string{"text/plain", "text/html"}
+var contentTypes = [...]string{"text/plain", "text/html", "text/calendar"}
 
 func (contentType contentType) string() string {
 	return contentTypes[contentType]


### PR DESCRIPTION
Should satisfy #49.

Example usage would be something like:

```
email.AddAlternative(smtp.TextCalendar, string(icsData))
```