### PR TITLE
fix MIME-Version header

### DIFF
--- a/email.go
+++ b/email.go
@@ -497,8 +497,10 @@ func (email *Email) AddHeader(header string, values ...string) *Email {
 		return email
 	}
 
-	// Set header to correct canonical Mime
-	header = textproto.CanonicalMIMEHeaderKey(header)
+	if header != "MIME-Version" {
+		// Set header to correct canonical Mime
+		header = textproto.CanonicalMIMEHeaderKey(header)
+	}
 
 	switch header {
 	case "Sender":


### PR DESCRIPTION
Correct mime version header is `MIME-Version` not canonical `Mime-Version` - [rfc4021](https://www.rfc-editor.org/rfc/rfc4021.html#page-44)

No more MV_CASE points in rspamd