### PR TITLE
refactor(email): export priority type

### DIFF
--- a/email.go
+++ b/email.go
@@ -384,18 +384,18 @@ func addAddress(addressList []string, address string, allowDuplicateAddress bool
 	return append(addressList, address), nil
 }
 
-type priority int
+type Priority int
 
 const (
-	// PriorityLow sets the email priority to Low
-	PriorityLow priority = iota
-	// PriorityHigh sets the email priority to High
+	// PriorityLow sets the email Priority to Low
+	PriorityLow Priority = iota
+	// PriorityHigh sets the email Priority to High
 	PriorityHigh
 )
 
-// SetPriority sets the email message priority. Use with
+// SetPriority sets the email message Priority. Use with
 // either "High" or "Low".
-func (email *Email) SetPriority(priority priority) *Email {
+func (email *Email) SetPriority(priority Priority) *Email {
 	if email.Error != nil {
 		return email
 	}


### PR DESCRIPTION
### Summary

This PR exports the [priority type](https://github.com/xhit/go-simple-mail/blob/457c8da4d84b1dc44cf64adb726f344129acc41d/email.go#L387), which eventually helps users of the library to translate the built-in priority type to their own priority type.

This closes #83.

### Changes

- Exported priority type (didn't add a comment to follow style of the repo, e.g. [AuthType](https://github.com/xhit/go-simple-mail/blob/457c8da4d84b1dc44cf64adb726f344129acc41d/email.go#L133))