### PR TITLE
Add a toggle to skip email validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Note 1: by default duplicated recipients throws an error, from `v2.13.0` you can
 
 Note 2: by default Bcc header is not set in email. From `v2.14.0` you can use `email.AddBccToHeader = true` to add this.
 
+Note 3: by default all addresses are validated against RFC5322. Setting `email.UseProvidedAddress = true` skips this validation, but requires you to ensure a valid address is sent.
+
 ## Download
 
 This package uses go modules.


### PR DESCRIPTION
This PR adds an option `UseProvidedAddress` which when set directly uses the email provided by the user without validating or trying to parse out its components.

Closes https://github.com/xhit/go-simple-mail/issues/95