### PR TITLE
Use ContentID if provided to lookup attachments

### DIFF
--- a/attach.go
+++ b/attach.go
@@ -16,6 +16,8 @@ import (
 type File struct {
 	// FilePath is the path of the file to attach.
 	FilePath string
+	// ContentID is the contentID of the attachment. Optional. Used instead of Name to look up inline attachment in the body if provided.
+	ContentID string
 	// Name is the name of file in attachment. Required for Data and B64Data. Optional for FilePath.
 	Name string
 	// MimeType of attachment. If empty then is obtained from Name (if not empty) or FilePath. If cannot obtained, application/octet-stream is set.

--- a/message.go
+++ b/message.go
@@ -238,7 +238,11 @@ func (msg *message) addFiles(files []*File, inline bool) {
 		header.Set("Content-Transfer-Encoding", encoding.string())
 		if inline {
 			header.Set("Content-Disposition", "inline;\n \tfilename=\""+encodeHeader(escapeQuotes(file.Name), msg.charset, 10)+`"`)
-			header.Set("Content-ID", "<"+msg.getCID(file.Name)+">")
+			if len(file.ContentID) > 0 {
+				header.Set("Content-ID", "<"+msg.getCID(file.ContentID)+">")
+			} else {
+				header.Set("Content-ID", "<"+msg.getCID(file.Name)+">")
+			}
 		} else {
 			header.Set("Content-Disposition", "attachment;\n \tfilename=\""+encodeHeader(escapeQuotes(file.Name), msg.charset, 10)+`"`)
 		}


### PR DESCRIPTION
`File` struct now has an optional `ContentID` field which if provided is used to look up inline attachments in the body instead of Name.

Closes https://github.com/xhit/go-simple-mail/issues/101