### PR TITLE
Expose `HasDSNExt` Flag to determine if email is sent with "Fire and forget" or "Has been delivered"

### DIFF
--- a/email.go
+++ b/email.go
@@ -75,7 +75,7 @@ type SMTPClient struct {
 	Client                    *smtpClient
 	SendTimeout               time.Duration
 	KeepAlive                 bool
-	hasDSNExt                 bool
+	HasDSNExt                 bool
 	preserveOriginalRecipient bool
 	dsn                       []DSN
 }
@@ -956,7 +956,7 @@ func (server *SMTPServer) Connect() (*SMTPClient, error) {
 		Client:      c,
 		KeepAlive:   server.KeepAlive,
 		SendTimeout: server.SendTimeout,
-		hasDSNExt:   hasDSN,
+		HasDSNExt:   hasDSN,
 	}, server.validateAuth(c)
 }
 
@@ -1057,7 +1057,7 @@ func sendMailProcess(from string, to []string, msg string, c *SMTPClient) error 
 	var dsn string
 	var dsnSet bool
 
-	if c.hasDSNExt && len(c.dsn) > 0 {
+	if c.HasDSNExt && len(c.dsn) > 0 {
 		dsn = " NOTIFY="
 		if hasNeverDSN(c.dsn) {
 			dsn += NEVER.String()


### PR DESCRIPTION
## Description
This PR introduces a new public field `HasDSNExt` to the email struct, which was previously private and named `hasDSNExt`. This change provides a way to determine whether an email was sent with "Fire and forget" or if it has been delivered.

## Changes
 - Struct Field Update: Renamed the private field hasDSNExt to the public field HasDSNExt in the email struct.
 - Functionality: Exposed HasDSNExt to allow users to check if the email delivery status is tracked.

## Motivation
The motivation for this change is to enhance the visibility of the delivery status flag for users who need to confirm whether an email was sent with "Fire and forget" semantics or if it has been delivered.

## Impact
 - Public API: This change affects the public API by exposing the previously private field.
 - Backward Compatibility: No breaking changes. Existing functionality remains intact, but users now have access to the delivery status flag.